### PR TITLE
Small updates to the Ray workflow

### DIFF
--- a/PRODUCTION_IWP_CONFIG.py
+++ b/PRODUCTION_IWP_CONFIG.py
@@ -104,4 +104,5 @@ IWP_CONFIG = {
     ]
   ],
   "deduplicate_method": "footprints",
+  "deduplicate_clip_to_footprint": True
 }


### PR DESCRIPTION
1. Add clipping by footprint to the config
2. Don't create directories in the PathManager that already exist
3. Pass the updated config to web-tiler after the ranges are updated

Change 3 might prevent the divide by zero error.