### PR TITLE
Minor updates to parsl workflow

### DIFF
--- a/pdg_workflow/pdg_workflow.py
+++ b/pdg_workflow/pdg_workflow.py
@@ -204,6 +204,7 @@ def run_pdg_workflow(
 
     # Update ranges
     rasterizer.update_ranges()
+    updated_workflow_config = rasterizer.config.config
 
     # Process web tiles in batches
     geotiff_paths = tile_manager.get_filenames_from_dir('geotiff')
@@ -211,7 +212,7 @@ def run_pdg_workflow(
 
     app_futures = []
     for batch in geotiff_batches:
-        app_future = create_web_tiles(batch, workflow_config, logging_dict)
+        app_future = create_web_tiles(batch, updated_workflow_config, logging_dict)
         app_futures.append(app_future)
 
     # Don't record end time until all web tiles have been created

--- a/workflow_configs/ice-wedge-polygons.json
+++ b/workflow_configs/ice-wedge-polygons.json
@@ -10,7 +10,7 @@
   "version": "DATE",
   "ext_input": ".shp",
   "simplify_tolerance": 0.1,
-  "tms_id": "WorldCRS84Quad",
+  "tms_id": "WGS1984Quad",
   "z_range": [0, 16],
   "geometricError": 57,
   "z_coord": 0,
@@ -40,5 +40,6 @@
   ],
   "deduplicate_at": ["raster", "3dtiles"],
   "deduplicate_method": "footprints",
-  "deduplicate_keep_rules": [["Date", "larger"]]
+  "deduplicate_keep_rules": [["Date", "larger"]],
+  "deduplicate_clip_to_footprint": true
 }


### PR DESCRIPTION
1. Update IWP config to use WGS1984Quad
2. Clip by footprint during deduplication of IWP
3. Pass updated config to the web tiles function after we update the ranges

Number 3 might fix the divide by zero warning